### PR TITLE
Fix type error in zenity driver

### DIFF
--- a/crossfiledialog/zenity.py
+++ b/crossfiledialog/zenity.py
@@ -45,10 +45,11 @@ def run_zenity(*args, **kwargs):
     if process.returncode == -1:
         raise ZenityException("Unexpected error during zenity call")
 
+    stdout, stderr = stdout.decode(), stderr.decode()
+
     if stderr.strip():
         sys.stderr.write(stderr)
 
-    stdout, stderr = stdout.decode(), stderr.decode()
     return stdout.strip()
 
 


### PR DESCRIPTION
Fixed a bug in `zenity` driver that caused Python to raise an exception when bytes were passed to `stderr.write` instead of a string. Since both standard input and error of `zenity` were decoded anyway, this step was simply moved upwards.