### PR TITLE
Add customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Currently supports:
  - KDialog (KDE)
  - Windows 2000 and newer (via PyWin32)
 
-
-
 Basic API usage:
 
 ```python
@@ -25,4 +23,72 @@ save_filename = crossfiledialog.save_file()
 foldername = crossfiledialog.choose_folder()
 ```
 
+## Documentation
+```python
+crossfiledialog.open_file(title, start_dir, filter) -> str
+```
+Open a file selection dialog for selecting a file.
+
+Parameters:
+ - title (str, optional) — The title of the file selection dialog. Default is 'Choose a file'
+ - start_dir (str, optional) — The starting directory for the dialog.
+ - filter (str, list, dict, optional) — The filter for file types to display. It can be either:
+   - a single wildcard (e.g.: `"*.py"`, all files are displayed ending .py)
+   - a list of wildcards (e.g.: `["*.py" "*.md"]`, all files are displayed ending either .py or .md)
+   - a list of list optional one or more wildcards (e.g.: `[["*.py", "*.md"], ["*.txt"]]`, 
+ user can switch between (.py, .md) and (.txt))
+   - a dictionary mapping descriptions to wildcards (e.g.: `{"PDF-Files": "*.pdf", "Python Project": ["\*.py", "*.md"]}`)
+
+Returns:
+ - str: The selected file's path.
+
+---
+
+```python
+crossfiledialog.open_multiple(title, start_dir, filter) -> list[str]
+```
+Open a file selection dialog for selecting multiple files.
+
+Parameters:
+ - title (str, optional) — The title of the file selection dialog. Default is 'Choose one or more files'
+ - start_dir (str, optional) — The starting directory for the dialog.
+ - filter (str, list, dict, optional) — The filter for file types to display. It can be either:
+   - a single wildcard (e.g.: `"*.py"`, all files are displayed ending .py)
+   - a list of wildcards (e.g.: `["*.py" "*.md"]`, all files are displayed ending either .py or .md)
+   - a list of list optional one or more wildcards (e.g.: `[["*.py", "*.md"], ["*.txt"]]`, 
+ user can switch between (.py, .md) and (.txt))
+   - a dictionary mapping descriptions to wildcards (e.g.: `{"PDF-Files": "*.pdf", "Python Project": ["\*.py", "*.md"]}`)
+
+Returns:
+ - list[str]: A list of selected file paths.
+
+---
+
+```python
+crossfiledialog.save_file(title, start_dir) -> str
+```
+Open a save file dialog.
+
+Parameters:
+ - title (str, optional) — The title of the file selection dialog. Default is 'Enter the name of the file to save to'
+ - start_dir (str, optional) — The starting directory for the dialog.
+
+Returns:
+ - str: The selected file's path for saving.
+
+---
+
+```python
+crossfiledialog.save_file(title, start_dir) -> str
+``
+Open a folder selection dialog.
+
+Parameters:
+ - title (str, optional) — The title of the file selection dialog. Default is 'Choose a folder'
+ - start_dir (str, optional) — The starting directory for the dialog.
+
+Returns:
+ - str: The selected folder's path.
+
+## Licence
 Licensed under the GNU GPL 3.0

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Currently supports:
  - KDialog (KDE)
  - Windows 2000 and newer (via PyWin32)
 
-
-
 Basic API usage:
 
 ```python
@@ -25,4 +23,60 @@ save_filename = crossfiledialog.save_file()
 foldername = crossfiledialog.choose_folder()
 ```
 
+## Documentation
+### crossfiledialog.open_file(title, start_dir, filter) -> str
+
+Open a file selection dialog for selecting a file.
+
+Parameters:
+ - title (str, optional) — The title of the file selection dialog. Default is 'Choose a file'
+ - start_dir (str, optional) — The starting directory for the dialog.
+ - filter (str, list, dict, optional) — The filter for file types to display. It can be either:
+   - a single wildcard (e.g.: `"*.py"`, all files are displayed ending .py)
+   - a list of wildcards (e.g.: `["*.py" "*.md"]`, all files are displayed ending either .py or .md)
+   - a list of list optional one or more wildcards (e.g.: `[["*.py", "*.md"], ["*.txt"]]`, 
+ user can switch between (.py, .md) and (.txt))
+   - a dictionary mapping descriptions to wildcards (e.g.: `{"PDF-Files": "*.pdf", "Python Project": ["\*.py", "*.md"]}`)
+
+Returns:
+ - str: The selected file's path.
+
+### crossfiledialog.open_multiple(title, start_dir, filter) -> list[str]
+
+Open a file selection dialog for selecting multiple files.
+
+Parameters:
+ - title (str, optional) — The title of the file selection dialog. Default is 'Choose one or more files'
+ - start_dir (str, optional) — The starting directory for the dialog.
+ - filter (str, list, dict, optional) — The filter for file types to display. It can be either:
+   - a single wildcard (e.g.: `"*.py"`, all files are displayed ending .py)
+   - a list of wildcards (e.g.: `["*.py" "*.md"]`, all files are displayed ending either .py or .md)
+   - a list of list optional one or more wildcards (e.g.: `[["*.py", "*.md"], ["*.txt"]]`, 
+ user can switch between (.py, .md) and (.txt))
+   - a dictionary mapping descriptions to wildcards (e.g.: `{"PDF-Files": "*.pdf", "Python Project": ["\*.py", "*.md"]}`)
+
+Returns:
+ - list[str]: A list of selected file paths.
+
+### crossfiledialog.save_file(title, start_dir) -> str
+Open a save file dialog.
+
+Parameters:
+ - title (str, optional) — The title of the file selection dialog. Default is 'Enter the name of the file to save to'
+ - start_dir (str, optional) — The starting directory for the dialog.
+
+Returns:
+ - str: The selected file's path for saving.
+
+### crossfiledialog.save_file(title, start_dir) -> str
+Open a folder selection dialog.
+
+Parameters:
+ - title (str, optional) — The title of the file selection dialog. Default is 'Choose a folder'
+ - start_dir (str, optional) — The starting directory for the dialog.
+
+Returns:
+ - str: The selected folder's path.
+
+## Licence
 Licensed under the GNU GPL 3.0

--- a/crossfiledialog/__init__.py
+++ b/crossfiledialog/__init__.py
@@ -1,2 +1,1 @@
 from crossfiledialog.wrapper import *
-

--- a/crossfiledialog/kdialog.py
+++ b/crossfiledialog/kdialog.py
@@ -6,6 +6,7 @@ from subprocess import PIPE, Popen
 from crossfiledialog import strings
 from crossfiledialog.exceptions import FileDialogException
 
+# TODO: more testing
 
 class KDialogException(FileDialogException):
     pass
@@ -29,9 +30,13 @@ def set_last_cwd(cwd):
     last_cwd = os.path.dirname(cwd)
 
 
-def run_kdialog(*args, **kwargs):
+def run_kdialog(*args, **kwargs):   
     cmdlist = ['kdialog']
     cmdlist.extend('--{0}'.format(arg) for arg in args)
+
+    if "start_dir" in kwargs:
+        cmdlist.append(kwargs.pop("start_dir"))
+
     for k, v in kwargs.items():
         cmdlist.append('--{0}'.format(k))
         cmdlist.append(v)
@@ -54,8 +59,11 @@ def run_kdialog(*args, **kwargs):
     return stdout.strip()
 
 
-def open_file(title=strings.open_file, filter=None):
+def open_file(title=strings.open_file, start_dir=None, filter=None):
     kdialog_kwargs = dict(title=title)
+    
+    if start_dir:
+        kdialog_kwargs["start_dir"] = start_dir
 
     if filter:
         pass
@@ -66,8 +74,12 @@ def open_file(title=strings.open_file, filter=None):
     return result
 
 
-def open_multiple(title=strings.open_multiple):
+def open_multiple(title=strings.open_multiple, start_dir=None):
     kdialog_kwargs = dict(title=title)
+
+    if start_dir:
+        kdialog_kwargs["start_dir"] = start_dir
+
 
     if filter:
         pass
@@ -80,17 +92,25 @@ def open_multiple(title=strings.open_multiple):
     return []
 
 
-def save_file(title=strings.save_file):
+def save_file(title=strings.save_file, start_dir=None):
     kdialog_args = ['getsavefilename']
     kdialog_kwargs = dict(title=title)
+
+    if start_dir:
+        kdialog_kwargs["start_dir"] = start_dir
+
     result = run_kdialog(*kdialog_args, **kdialog_kwargs)
     if result:
         set_last_cwd(result)
     return result
 
 
-def choose_folder(title=strings.choose_folder):
+def choose_folder(title=strings.choose_folder, start_dir=None):
     kdialog_kwargs = dict(title=title)
+
+    if start_dir:
+        kdialog_kwargs["start_dir"] = start_dir
+
     result = run_kdialog('getexistingdirectory', **kdialog_kwargs)
     if result:
         set_last_cwd(result)

--- a/crossfiledialog/kdialog.py
+++ b/crossfiledialog/kdialog.py
@@ -62,6 +62,21 @@ def run_kdialog(*args, **kwargs):
 
 
 def open_file(title=strings.open_file, start_dir=None, filter=None):
+    """
+    Open a file selection dialog for selecting a file using KDialog.
+
+    Args:
+        title (str, optional): The title of the file selection dialog.
+            Default is 'Choose a file'
+        start_dir (str, optional): The starting directory for the dialog.
+        filter (str, list, dict, optional): The filter for file types to display.
+
+    Returns:
+        str: The selected file's path.
+
+    Example:
+        result = open_file(title="Select a file", start_dir="/path/to/starting/directory", filter="*.txt")
+    """
     kdialog_kwargs = dict(title=title)
 
     if start_dir:
@@ -69,27 +84,27 @@ def open_file(title=strings.open_file, start_dir=None, filter=None):
 
     if filter:
         if isinstance(filter, str):
-            # filter is a single wildcard
+            # Filter is a single wildcard.
             kdialog_kwargs["filter"] = filter
         elif isinstance(filter, list):
             if isinstance(filter[0], str):
-                # filter is a list of wildcards
+                # Filter is a list of wildcards.
                 kdialog_kwargs["filter"] = " ".join(filter)
             elif isinstance(filter[0], list):
-                # filter is a list of list with wildcards
+                # Filter is a list of lists with wildcards.
                 kdialog_kwargs["filter"] = " | ".join(
                     " ".join(f) for f in filter
                 )
             else:
                 raise ValueError("Invalid filter")
         elif isinstance(filter, dict):
-            # filter is a dictionary mapping descriptions to wildcards or lists of wildcards
+            # Filter is a dictionary mapping descriptions to wildcards or lists of wildcards.
             filters = []
             for key, value in filter.items():
                 if isinstance(value, str):
-                    filters.append(f"{key} ({value})")
+                    filters.append("{0} ({1})".format(key, value))
                 elif isinstance(value, list):
-                    filters.append(f"{key} ({' '.join(value)})")
+                    filters.append("{0} ({1})".format(key, ' '.join(value)))
                 else:
                     raise ValueError("Invalid filter")
 
@@ -105,7 +120,23 @@ def open_file(title=strings.open_file, start_dir=None, filter=None):
     return result
 
 
-def open_multiple(title=strings.open_multiple, start_dir=None):
+def open_multiple(title=strings.open_multiple, start_dir=None, filter=None):
+    """
+    Open a file selection dialog for selecting multiple files using KDialog.
+
+    Args:
+        title (str, optional): The title of the file selection dialog.
+            Default is 'Choose one or more files'
+        start_dir (str, optional): The starting directory for the dialog.
+        filter (optional): The filter for file types to display.
+
+    Returns:
+        list[str]: A list of selected file paths.
+
+    Example:
+        result = open_multiple(title="Select multiple files",
+        start_dir="/path/to/starting/directory", filter="*.txt")
+    """
     kdialog_kwargs = dict(title=title)
 
     if start_dir:
@@ -113,27 +144,27 @@ def open_multiple(title=strings.open_multiple, start_dir=None):
 
     if filter:
         if isinstance(filter, str):
-            # filter is a single wildcard
+            # Filter is a single wildcard.
             kdialog_kwargs["filter"] = filter
         elif isinstance(filter, list):
             if isinstance(filter[0], str):
-                # filter is a list of wildcards
+                # Filter is a list of wildcards.
                 kdialog_kwargs["filter"] = " ".join(filter)
             elif isinstance(filter[0], list):
-                # filter is a list of list with wildcards
+                # Filter is a list of lists with wildcards.
                 kdialog_kwargs["filter"] = " | ".join(
                     " ".join(f) for f in filter
                 )
             else:
                 raise ValueError("Invalid filter")
         elif isinstance(filter, dict):
-            # filter is a dictionary mapping descriptions to wildcards or lists of wildcards
+            # Filter is a dictionary mapping descriptions to wildcards or lists of wildcards.
             filters = []
             for key, value in filter.items():
                 if isinstance(value, str):
-                    filters.append(f"{key} ({value})")
+                    filters.append("{0} ({1})".format(key, value))
                 elif isinstance(value, list):
-                    filters.append(f"{key} ({' '.join(value)})")
+                    filters.append("{0} ({1})".format(key, ' '.join(value)))
                 else:
                     raise ValueError("Invalid filter")
 
@@ -152,6 +183,20 @@ def open_multiple(title=strings.open_multiple, start_dir=None):
 
 
 def save_file(title=strings.save_file, start_dir=None):
+    """
+    Open a save file dialog using KDialog.
+
+    Args:
+        title (str, optional): The title of the save file dialog.
+            Default is 'Enter the name of the file to save to'
+        start_dir (str, optional): The starting directory for the dialog.
+
+    Returns:
+        str: The selected file's path for saving.
+
+    Example:
+        result = save_file(title="Save file", start_dir="/path/to/starting/directory")
+    """
     kdialog_args = ['getsavefilename']
     kdialog_kwargs = dict(title=title)
 
@@ -165,6 +210,20 @@ def save_file(title=strings.save_file, start_dir=None):
 
 
 def choose_folder(title=strings.choose_folder, start_dir=None):
+    """
+    Open a folder selection dialog using KDialog.
+
+    Args:
+        title (str, optional): The title of the folder selection dialog.
+            Default is 'Choose a folder'
+        start_dir (str, optional): The starting directory for the dialog.
+
+    Returns:
+        str: The selected folder's path.
+
+    Example:
+        result = choose_folder(title="Select folder", start_dir="/path/to/starting/directory")
+    """
     kdialog_kwargs = dict(title=title)
 
     if start_dir:

--- a/crossfiledialog/win32.py
+++ b/crossfiledialog/win32.py
@@ -20,7 +20,6 @@ class Win32Exception(FileDialogException):
 
 last_cwd = None
 
-# TODO: Testing
 
 def get_preferred_cwd():
     possible_cwd = os.environ.get('FILEDIALOG_CWD', '')
@@ -60,7 +59,6 @@ def open_file(title=strings.open_file, start_dir=None, filter=None):
     if start_dir:
         win_kwargs["InitialDir"] = start_dir
 
-
     file_name = error_handling_wrapper(
         win32gui.GetOpenFileNameW,
         **win_kwargs
@@ -71,7 +69,7 @@ def open_file(title=strings.open_file, start_dir=None, filter=None):
     return file_name
 
 
-def open_multiple(title=strings.open_multiple, start_dir=None):
+def open_multiple(title=strings.open_multiple, start_dir=None, filter=None):
     win_kwargs = dict(Title=title)
 
     if start_dir:

--- a/crossfiledialog/win32.py
+++ b/crossfiledialog/win32.py
@@ -20,6 +20,7 @@ class Win32Exception(FileDialogException):
 
 last_cwd = None
 
+# TODO: Testing
 
 def get_preferred_cwd():
     possible_cwd = os.environ.get('FILEDIALOG_CWD', '')
@@ -53,10 +54,16 @@ def error_handling_wrapper(struct, **kwargs):
         return None
 
 
-def open_file(title=strings.open_file, filter=None):
+def open_file(title=strings.open_file, start_dir=None, filter=None):
+    win_kwargs = dict(Title=title)
+
+    if start_dir:
+        win_kwargs["InitialDir"] = start_dir
+
+
     file_name = error_handling_wrapper(
         win32gui.GetOpenFileNameW,
-        Title=title
+        **win_kwargs
     )
 
     if file_name:
@@ -64,10 +71,15 @@ def open_file(title=strings.open_file, filter=None):
     return file_name
 
 
-def open_multiple(title=strings.open_multiple):
+def open_multiple(title=strings.open_multiple, start_dir=None):
+    win_kwargs = dict(Title=title)
+
+    if start_dir:
+        win_kwargs["InitialDir"] = start_dir
+
     file_names = error_handling_wrapper(
         win32gui.GetOpenFileNameW,
-        Title=title,
+        **win_kwargs,
         Flags=win32con.OFN_ALLOWMULTISELECT,
     )
 
@@ -84,10 +96,15 @@ def open_multiple(title=strings.open_multiple):
     return []
 
 
-def save_file(title=strings.save_file):
+def save_file(title=strings.save_file, start_dir=None):
+    win_kwargs = dict(Title=title)
+
+    if start_dir:
+        win_kwargs["InitialDir"] = start_dir
+
     file_name = error_handling_wrapper(
         win32gui.GetSaveFileNameW,
-        Title=title,
+        **win_kwargs,
         Flags=win32con.OFN_OVERWRITEPROMPT,
     )
 
@@ -96,10 +113,16 @@ def save_file(title=strings.save_file):
     return file_name
 
 
-def choose_folder(title=strings.choose_folder):
-    desktop_pidl = shell.SHGetFolderLocation(0, shellcon.CSIDL_DESKTOP, 0, 0)
+def choose_folder(title=strings.choose_folder, start_dir=None):
+    if start_dir:
+        start_pidl, _, _ = shell.SHParseDisplayName(start_dir, 0, 0, 0)
+    elif last_cwd:
+        start_pidl, _, _ = shell.SHParseDisplayName(last_cwd, 0, 0, 0)
+    else:
+        # default directory is the desktop
+        start_pidl = shell.SHGetFolderLocation(0, shellcon.CSIDL_DESKTOP, 0, 0)
     pidl, display_name, image_list = shell.SHBrowseForFolder(
-        win32gui.GetDesktopWindow(), desktop_pidl,
+        win32gui.GetDesktopWindow(), start_pidl,
         title, 0, None, None
     )
 

--- a/crossfiledialog/win32.py
+++ b/crossfiledialog/win32.py
@@ -54,6 +54,21 @@ def error_handling_wrapper(struct, **kwargs):
 
 
 def open_file(title=strings.open_file, start_dir=None, filter=None):
+    """
+    Open a file selection dialog for selecting a file using the Windows API.
+
+    Args:
+        title (str, optional): The title of the file selection dialog.
+            Default is 'Choose a file'
+        start_dir (str, optional): The starting directory for the dialog.
+        filter (str, list, dict, optional): The filter for file types to display.
+
+    Returns:
+        str: The selected file's path.
+
+    Example:
+        result = open_file(title="Select a file", start_dir="C:/Documents", filter="*.txt")
+    """
     win_kwargs = dict(Title=title)
 
     if start_dir:
@@ -61,21 +76,21 @@ def open_file(title=strings.open_file, start_dir=None, filter=None):
 
     if filter:
         if isinstance(filter, str):
-            # filter is a single wildcard
+            # Filter is a single wildcard.
             win_kwargs["Filter"] = filter + '\0' + filter + '\0'
         elif isinstance(filter, list):
             if isinstance(filter[0], str):
-                # filter is a list of wildcards
-                win_kwargs["Filter"] =  " ".join(filter) + '\0' + ";".join(filter) + '\0'
+                # Filter is a list of wildcards.
+                win_kwargs["Filter"] = " ".join(filter) + '\0' + ";".join(filter) + '\0'
             elif isinstance(filter[0], list):
-                # filter is a list of list with wildcards
+                # Filter is a list of list with wildcards.
                 win_kwargs["Filter"] = "".join(
-                     " ".join(f) + '\0' + ";".join(f) + '\0' for f in filter
+                    " ".join(f) + '\0' + ";".join(f) + '\0' for f in filter
                 )
             else:
                 raise ValueError("Invalid filter")
         elif isinstance(filter, dict):
-            # filter is a dictionary mapping descriptions to wildcards or lists of wildcards
+            # Filter is a dictionary mapping descriptions to wildcards or lists of wildcards.
             filters = ""
             for key, value in filter.items():
                 if isinstance(value, str):
@@ -86,7 +101,6 @@ def open_file(title=strings.open_file, start_dir=None, filter=None):
                     raise ValueError("Invalid filter")
 
             win_kwargs["Filter"] = filters
-
         else:
             raise ValueError("Invalid filter")
 
@@ -101,28 +115,43 @@ def open_file(title=strings.open_file, start_dir=None, filter=None):
 
 
 def open_multiple(title=strings.open_multiple, start_dir=None, filter=None):
+    """
+    Open a file selection dialog for selecting multiple files using the Windows API.
+
+    Args:
+        title (str, optional): The title of the file selection dialog.
+            Default is 'Choose one or more files'
+        start_dir (str, optional): The starting directory for the dialog.
+        filter (str, list, dict, optional): The filter for file types to display.
+
+    Returns:
+        list[str]: A list of selected file paths.
+
+    Example:
+        result = open_multiple(title="Select multiple files", start_dir="C:/Documents", filter="*.txt")
+    """
     win_kwargs = dict(Title=title)
 
     if start_dir:
         win_kwargs["InitialDir"] = start_dir
-    
+
     if filter:
         if isinstance(filter, str):
-            # filter is a single wildcard
+            # Filter is a single wildcard.
             win_kwargs["Filter"] = filter + '\0' + filter + '\0'
         elif isinstance(filter, list):
             if isinstance(filter[0], str):
-                # filter is a list of wildcards
-                win_kwargs["Filter"] =  " ".join(filter) + '\0' + ";".join(filter) + '\0'
+                # Filter is a list of wildcards.
+                win_kwargs["Filter"] = " ".join(filter) + '\0' + ";".join(filter) + '\0'
             elif isinstance(filter[0], list):
-                # filter is a list of list with wildcards
+                # Filter is a list of list with wildcards.
                 win_kwargs["Filter"] = "".join(
-                     " ".join(f) + '\0' + ";".join(f) + '\0' for f in filter
+                    " ".join(f) + '\0' + ";".join(f) + '\0' for f in filter
                 )
             else:
                 raise ValueError("Invalid filter")
         elif isinstance(filter, dict):
-            # filter is a dictionary mapping descriptions to wildcards or lists of wildcards
+            # Filter is a dictionary mapping descriptions to wildcards or lists of wildcards.
             filters = ""
             for key, value in filter.items():
                 if isinstance(value, str):
@@ -133,10 +162,8 @@ def open_multiple(title=strings.open_multiple, start_dir=None, filter=None):
                     raise ValueError("Invalid filter")
 
             win_kwargs["Filter"] = filters
-
         else:
             raise ValueError("Invalid filter")
-
 
     file_names = error_handling_wrapper(
         win32gui.GetOpenFileNameW,
@@ -158,6 +185,20 @@ def open_multiple(title=strings.open_multiple, start_dir=None, filter=None):
 
 
 def save_file(title=strings.save_file, start_dir=None):
+    """
+    Open a save file dialog using the Windows API.
+
+    Args:
+        title (str, optional): The title of the save file dialog.
+            Default is 'Enter the name of the file to save to'
+        start_dir (str, optional): The starting directory for the dialog.
+
+    Returns:
+        str: The selected file's path for saving.
+
+    Example:
+        result = save_file(title="Save file", start_dir="C:/Documents")
+    """
     win_kwargs = dict(Title=title)
 
     if start_dir:
@@ -175,6 +216,20 @@ def save_file(title=strings.save_file, start_dir=None):
 
 
 def choose_folder(title=strings.choose_folder, start_dir=None):
+    """
+    Open a folder selection dialog using the Windows API.
+
+    Args:
+        title (str, optional): The title of the folder selection dialog.
+            Default is 'Choose a folder'
+        start_dir (str, optional): The starting directory for the dialog.
+
+    Returns:
+        str: The selected folder's path.
+
+    Example:
+        result = choose_folder(title="Choose folder", start_dir="C:/Documents")
+    """
     if start_dir:
         start_pidl, _ = shell.SHParseDisplayName(start_dir, 0, None)
     elif last_cwd:

--- a/crossfiledialog/zenity.py
+++ b/crossfiledialog/zenity.py
@@ -42,7 +42,7 @@ def run_zenity(*args, **kwargs):
     process = Popen(cmdlist, stdout=PIPE, stderr=PIPE, **extra_kwargs)
     stdout, stderr = process.communicate()
 
-    if process.returncode == -1:        
+    if process.returncode == -1:
         raise ZenityException("Unexpected error during zenity call")
 
     stdout, stderr = stdout.decode(), stderr.decode()
@@ -54,34 +54,48 @@ def run_zenity(*args, **kwargs):
 
 
 def open_file(title=strings.open_file, start_dir=None, filter=None):
+    """
+    Open a file selection dialog for selecting a file using Zenity.
+
+    Args:
+        title (str, optional): The title of the file selection dialog.
+            Default is 'Choose a file'
+        start_dir (str, optional): The starting directory for the dialog.
+        filter (str, list, dict, optional): The filter for file types to display.
+
+    Returns:
+        str: The selected file's path.
+
+    Example:
+        result = open_file(title="Select a file", start_dir="/path/to/starting/directory", filter="*.txt")
+    """
     zenity_args = []
     zenity_kwargs = dict(title=title)
-    
+
     if start_dir:
-        # if the path doesn't end with a backslash, zenity only
-        # starts in the parent directory and selects the directory
+        # If the path doesn't end with a backslash, Zenity only
+        # starts in the parent directory and selects the directory.
         if start_dir[-1] != "/":
             start_dir += "/"
         zenity_kwargs["filename"] = start_dir
 
     if filter:
         if isinstance(filter, str):
-            # filter is a single wildcard
+            # Filter is a single wildcard.
             zenity_kwargs["file-filter"] = filter
         elif isinstance(filter, list):
-            # filter is a list of wildcards
+            # Filter is a list of wildcards.
             if isinstance(filter[0], str):
                 zenity_kwargs["file-filter"] = " ".join(filter)
             elif isinstance(filter[0], list):
-                for f in filter:
-                    zenity_args.append(f"file-filter={' '.join(f)}")
+                zenity_args.extend("file-filter={0}".format(' '.join(f)) for f in filter)
         elif isinstance(filter, dict):
-            # filter is a dictionary mapping descriptions to wildcards
+            # Filter is a dictionary mapping descriptions to wildcards.
             for key, value in filter.items():
                 if isinstance(value, str):
-                    zenity_args.append(f"file-filter={key} | {value}")
+                    zenity_args.append("file-filter={0} | {1}".format(key, value))
                 elif isinstance(value, list):
-                    zenity_args.append(f"file-filter={key} | {' | '.join(value)}")
+                    zenity_args.append("file-filter={0} | {1}".format(key, ' | '.join(value)))
                 else:
                     raise ValueError("Invalid filter")
         else:
@@ -94,34 +108,49 @@ def open_file(title=strings.open_file, start_dir=None, filter=None):
 
 
 def open_multiple(title=strings.open_multiple, start_dir=None, filter=None):
+    """
+    Open a file selection dialog for selecting multiple files using Zenity.
+
+    Args:
+        title (str, optional): The title of the file selection dialog.
+            Default is 'Choose one or more files'
+        start_dir (str, optional): The starting directory for the dialog.
+        filter (str, list, dict, optional): The filter for file types to display.
+
+    Returns:
+        list[str]: A list of selected file paths.
+
+    Example:
+        result = open_multiple(title="Select multiple files",
+        start_dir="/path/to/starting/directory", filter="*.txt")
+    """
     zenity_args = []
     zenity_kwargs = dict(title=title)
 
     if start_dir:
-        # if the path doesn't end with a backslash, zenity only starts in the parent directory
-        # and selects the directory in the dialog
+        # If the path doesn't end with a backslash, Zenity only starts in the parent directory
+        # and selects the directory in the dialog.
         if start_dir[-1] != "/":
             start_dir += "/"
         zenity_kwargs["filename"] = start_dir
 
     if filter:
         if isinstance(filter, str):
-            # filter is a single wildcard
+            # Filter is a single wildcard.
             zenity_kwargs["file-filter"] = filter
         elif isinstance(filter, list):
-            # filter is a list of wildcards
+            # Filter is a list of wildcards.
             if isinstance(filter[0], str):
                 zenity_kwargs["file-filter"] = " ".join(filter)
             elif isinstance(filter[0], list):
-                for f in filter:
-                    zenity_args.append(f"file-filter={' '.join(f)}")
+                zenity_args.extend("file-filter={0}".format(' '.join(f)) for f in filter)
         elif isinstance(filter, dict):
-            # filter is a dictionary mapping descriptions to wildcards
+            # Filter is a dictionary mapping descriptions to wildcards.
             for key, value in filter.items():
                 if isinstance(value, str):
-                    zenity_args.append(f"file-filter={key} | {value}")
+                    zenity_args.append("file-filter={0} | {1}".format(key, value))
                 elif isinstance(value, list):
-                    zenity_args.append(f"file-filter={key} | {' | '.join(value)}")
+                    zenity_args.append("file-filter={0} | {1}".format(key, ' | '.join(value)))
                 else:
                     raise ValueError("Invalid filter")
         else:
@@ -136,12 +165,26 @@ def open_multiple(title=strings.open_multiple, start_dir=None, filter=None):
 
 
 def save_file(title=strings.save_file, start_dir=None):
+    """
+    Open a save file dialog using Zenity.
+
+    Args:
+        title (str, optional): The title of the save file dialog.
+            Default is 'Enter the name of the file to save to'
+        start_dir (str, optional): The starting directory for the dialog.
+
+    Returns:
+        str: The selected file's path for saving.
+
+    Example:
+        result = save_file(title="Save file", start_dir="/path/to/starting/directory")
+    """
     zenity_args = ['file-selection', 'save', 'confirm-overwrite']
     zenity_kwargs = dict(title=title)
 
     if start_dir:
-        # if the path doesn't end with a backslash, zenity only starts in the parent directory
-        # and selects the directory in the dialog
+        # If the path doesn't end with a backslash, Zenity only starts in the parent directory
+        # and selects the directory in the dialog.
         if start_dir[-1] != "/":
             start_dir += "/"
         zenity_kwargs["filename"] = start_dir
@@ -153,11 +196,25 @@ def save_file(title=strings.save_file, start_dir=None):
 
 
 def choose_folder(title=strings.choose_folder, start_dir=None):
+    """
+    Open a folder selection dialog using Zenity.
+
+    Args:
+        title (str, optional): The title of the folder selection dialog.
+            Default is 'Choose a folder'
+        start_dir (str, optional): The starting directory for the dialog.
+
+    Returns:
+        str: The selected folder's path.
+
+    Example:
+        result = choose_folder(title="Select folder", start_dir="/path/to/starting/directory")
+    """
     zenity_kwargs = dict(title=title)
 
     if start_dir:
-        # if the path doesn't end with a backslash, zenity only starts in the parent directory
-        # and selects the directory in the dialog
+        # If the path doesn't end with a backslash, Zenity only starts in the parent directory
+        # and selects the directory in the dialog.
         if start_dir[-1] != "/":
             start_dir += "/"
         zenity_kwargs["filename"] = start_dir

--- a/crossfiledialog/zenity.py
+++ b/crossfiledialog/zenity.py
@@ -53,8 +53,15 @@ def run_zenity(*args, **kwargs):
     return stdout.strip()
 
 
-def open_file(title=strings.open_file, filter=None):
+def open_file(title=strings.open_file, start_dir=None, filter=None):
     zenity_kwargs = dict(title=title)
+    
+    if start_dir:
+        # if path doesnt end with a backslash, zenity only starts in the parent directory 
+        # and selects the directory in the dialog
+        if start_dir[-1] != "/":
+            start_dir += "/"
+        zenity_kwargs["filename"] = start_dir
 
     if filter:
         pass
@@ -65,8 +72,15 @@ def open_file(title=strings.open_file, filter=None):
     return result
 
 
-def open_multiple(title=strings.open_multiple):
+def open_multiple(title=strings.open_multiple, start_dir=None):
     zenity_kwargs = dict(title=title)
+
+    if start_dir:
+        # if path doesnt end with a backslash, zenity only starts in the parent directory 
+        # and selects the directory in the dialog
+        if start_dir[-1] != "/":
+            start_dir += "/"
+        zenity_kwargs["filename"] = start_dir
 
     if filter:
         pass
@@ -79,17 +93,33 @@ def open_multiple(title=strings.open_multiple):
     return []
 
 
-def save_file(title=strings.save_file):
+def save_file(title=strings.save_file, start_dir=None):
     zenity_args = ['file-selection', 'save', 'confirm-overwrite']
     zenity_kwargs = dict(title=title)
+
+    if start_dir:
+        # if path doesnt end with a backslash, zenity only starts in the parent directory 
+        # and selects the directory in the dialog
+        if start_dir[-1] != "/":
+            start_dir += "/"
+        zenity_kwargs["filename"] = start_dir
+
     result = run_zenity(*zenity_args, **zenity_kwargs)
     if result:
         set_last_cwd(result)
     return result
 
 
-def choose_folder(title=strings.choose_folder):
+def choose_folder(title=strings.choose_folder, start_dir=None):
     zenity_kwargs = dict(title=title)
+
+    if start_dir:
+        # if path doesnt end with a backslash, zenity only starts in the parent directory 
+        # and selects the directory in the dialog
+        if start_dir[-1] != "/":
+            start_dir += "/"
+        zenity_kwargs["filename"] = start_dir
+
     result = run_zenity('file-selection', 'directory', **zenity_kwargs)
     if result:
         set_last_cwd(result)

--- a/crossfiledialog/zenity.py
+++ b/crossfiledialog/zenity.py
@@ -42,7 +42,7 @@ def run_zenity(*args, **kwargs):
     process = Popen(cmdlist, stdout=PIPE, stderr=PIPE, **extra_kwargs)
     stdout, stderr = process.communicate()
 
-    if process.returncode == -1:
+    if process.returncode == -1:        
         raise ZenityException("Unexpected error during zenity call")
 
     stdout, stderr = stdout.decode(), stderr.decode()
@@ -54,38 +54,80 @@ def run_zenity(*args, **kwargs):
 
 
 def open_file(title=strings.open_file, start_dir=None, filter=None):
+    zenity_args = []
     zenity_kwargs = dict(title=title)
     
     if start_dir:
-        # if path doesnt end with a backslash, zenity only starts in the parent directory 
-        # and selects the directory in the dialog
+        # if the path doesn't end with a backslash, zenity only
+        # starts in the parent directory and selects the directory
         if start_dir[-1] != "/":
             start_dir += "/"
         zenity_kwargs["filename"] = start_dir
 
     if filter:
-        pass
+        if isinstance(filter, str):
+            # filter is a single wildcard
+            zenity_kwargs["file-filter"] = filter
+        elif isinstance(filter, list):
+            # filter is a list of wildcards
+            if isinstance(filter[0], str):
+                zenity_kwargs["file-filter"] = " ".join(filter)
+            elif isinstance(filter[0], list):
+                for f in filter:
+                    zenity_args.append(f"file-filter={' '.join(f)}")
+        elif isinstance(filter, dict):
+            # filter is a dictionary mapping descriptions to wildcards
+            for key, value in filter.items():
+                if isinstance(value, str):
+                    zenity_args.append(f"file-filter={key} | {value}")
+                elif isinstance(value, list):
+                    zenity_args.append(f"file-filter={key} | {' | '.join(value)}")
+                else:
+                    raise ValueError("Invalid filter")
+        else:
+            raise ValueError("Invalid filter")
 
-    result = run_zenity('file-selection', **zenity_kwargs)
+    result = run_zenity('file-selection', *zenity_args, **zenity_kwargs)
     if result:
         set_last_cwd(result)
     return result
 
 
-def open_multiple(title=strings.open_multiple, start_dir=None):
+def open_multiple(title=strings.open_multiple, start_dir=None, filter=None):
+    zenity_args = []
     zenity_kwargs = dict(title=title)
 
     if start_dir:
-        # if path doesnt end with a backslash, zenity only starts in the parent directory 
+        # if the path doesn't end with a backslash, zenity only starts in the parent directory
         # and selects the directory in the dialog
         if start_dir[-1] != "/":
             start_dir += "/"
         zenity_kwargs["filename"] = start_dir
 
     if filter:
-        pass
+        if isinstance(filter, str):
+            # filter is a single wildcard
+            zenity_kwargs["file-filter"] = filter
+        elif isinstance(filter, list):
+            # filter is a list of wildcards
+            if isinstance(filter[0], str):
+                zenity_kwargs["file-filter"] = " ".join(filter)
+            elif isinstance(filter[0], list):
+                for f in filter:
+                    zenity_args.append(f"file-filter={' '.join(f)}")
+        elif isinstance(filter, dict):
+            # filter is a dictionary mapping descriptions to wildcards
+            for key, value in filter.items():
+                if isinstance(value, str):
+                    zenity_args.append(f"file-filter={key} | {value}")
+                elif isinstance(value, list):
+                    zenity_args.append(f"file-filter={key} | {' | '.join(value)}")
+                else:
+                    raise ValueError("Invalid filter")
+        else:
+            raise ValueError("Invalid filter")
 
-    result = run_zenity('file-selection', 'multiple', **zenity_kwargs)
+    result = run_zenity('file-selection', 'multiple', *zenity_args, **zenity_kwargs)
     split_result = result.split('|')
     if split_result:
         set_last_cwd(split_result[0])
@@ -98,7 +140,7 @@ def save_file(title=strings.save_file, start_dir=None):
     zenity_kwargs = dict(title=title)
 
     if start_dir:
-        # if path doesnt end with a backslash, zenity only starts in the parent directory 
+        # if the path doesn't end with a backslash, zenity only starts in the parent directory
         # and selects the directory in the dialog
         if start_dir[-1] != "/":
             start_dir += "/"
@@ -114,7 +156,7 @@ def choose_folder(title=strings.choose_folder, start_dir=None):
     zenity_kwargs = dict(title=title)
 
     if start_dir:
-        # if path doesnt end with a backslash, zenity only starts in the parent directory 
+        # if the path doesn't end with a backslash, zenity only starts in the parent directory
         # and selects the directory in the dialog
         if start_dir[-1] != "/":
             start_dir += "/"
@@ -127,4 +169,3 @@ def choose_folder(title=strings.choose_folder, start_dir=None):
 
 
 __all__ = ['open_file', 'open_multiple', 'save_file', 'choose_folder']
-

--- a/test.py
+++ b/test.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python3
 
 import crossfiledialog
+from crossfiledialog.zenity import open_file
 
 
 def test():
-    #print(crossfiledialog.open_file())
-    #print(crossfiledialog.open_multiple())
-    print(crossfiledialog.save_file())
-    print(crossfiledialog.choose_folder())
+    # TODO: Windows Testing
+    print(open_file(
+        start_dir="/home/sebastian/Programming/20_Python/21_Projects/PDFCat",
+        # filter={"PDF-Files": "*.pdf", "Python Project": ["*.py", "*.md]}
+        filter=[["*.py", "*.txt"], ["*.png", "*.jpg"]]
+        # filter=["*.py", "*.txt"]
+        # filter=".*py"
+    ))
+    # print(crossfiledialog.open_multiple())
+    # print(crossfiledialog.save_file())
+    # print(crossfiledialog.choose_folder())
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python3
 
 import crossfiledialog
+from crossfiledialog.win32 import open_file
 
 
 def test():
-    #print(crossfiledialog.open_file())
-    #print(crossfiledialog.open_multiple())
-    print(crossfiledialog.save_file())
-    print(crossfiledialog.choose_folder())
+    # TODO: Windows Testing
+    print(open_file(
+        start_dir="c:\\Users\\sebas\\OneDrive\\Documents\\Python\\crossfiledialog",
+        filter={"PDF-Files": "*.pdf", "Python Project": ["*.py", "*.md"]}
+        # filter=[["*.py", "*.txt"], ["*.png", "*.jpg"]]
+        # filter=["*.py", "*.md"]
+        # filter="*.py"
+    ))
+    # print(crossfiledialog.open_multiple())
+    # print(crossfiledialog.save_file())
+    # print(crossfiledialog.choose_folder())
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python3
 
 import crossfiledialog
-from crossfiledialog.win32 import open_file
-from crossfiledialog.zenity import open_file
 
 
 def test():
-    # TODO: Windows Testing
-    print(open_file(
-        start_dir="c:\\Users\\sebas\\OneDrive\\Documents\\Python\\crossfiledialog",
+    print(crossfiledialog.open_file(
+        start_dir="~",
         filter={"PDF-Files": "*.pdf", "Python Project": ["*.py", "*.md"]}
         # filter=[["*.py", "*.txt"], ["*.png", "*.jpg"]]
         # filter=["*.py", "*.md"]


### PR DESCRIPTION
In this pull request, I added new features to customize the file dialog (addresses #3) to the project and improves its documentation. Here's what's included:
 - optional starting directory for all four functions: It is now possible to specify the directory the file dialog should start in.
 - optional filter for `open_file` and `open_multiple`: It is now possible to specify one or more filter, changing what type of files are displayed in the file dialog.
 -  detailed documentation of all functions in code for IDEs as well as in README.md